### PR TITLE
Fix issue with string parameter with quote

### DIFF
--- a/odata4j-core/src/main/java/org/odata4j/expression/ExpressionParser.java
+++ b/odata4j-core/src/main/java/org/odata4j/expression/ExpressionParser.java
@@ -830,16 +830,11 @@ public class ExpressionParser {
   }
 
   private static int readQuotedString(String value, int start) {
-    int rt = start;
-    while (value.charAt(rt) != '\'' || (rt < value.length() - 1 && value.charAt(rt + 1) == '\'')) {
-      if (value.charAt(rt) != '\'') {
-        rt++;
-      } else {
-        rt += 2;
-      }
+    int rt = value.lastIndexOf('\'');
+    if (rt < start) {
+      throw new RuntimeException("Invalid quoted string expression: " + value);
     }
-    rt++;
-    return rt;
+    return rt + 1;
   }
 
   private static int readWhitespace(String value, int start) {

--- a/odata4j-core/src/test/java/org/odata4j/test/unit/expressions/ExpressionParserTest.java
+++ b/odata4j-core/src/test/java/org/odata4j/test/unit/expressions/ExpressionParserTest.java
@@ -1,0 +1,27 @@
+package org.odata4j.test.unit.expressions;
+
+import junit.framework.Assert;
+import org.junit.Test;
+import org.odata4j.expression.CommonExpression;
+import org.odata4j.expression.ExpressionParser;
+import org.odata4j.expression.PrintExpressionVisitor;
+
+public class ExpressionParserTest {
+    @Test
+    public void testLiteralExpression() {
+        CommonExpression expression = ExpressionParser.parse("'MyTestLibrary'");
+        Assert.assertNotNull(expression);
+        PrintExpressionVisitor visitor = new PrintExpressionVisitor();
+        expression.visitThis(visitor);
+        Assert.assertEquals("string(MyTestLibrary)", visitor.toString());
+    }
+
+    @Test
+    public void testLiteralWithQuoteExpression() {
+        CommonExpression expression = ExpressionParser.parse("''MyTestLibrary'");
+        Assert.assertNotNull(expression);
+        PrintExpressionVisitor visitor = new PrintExpressionVisitor();
+        expression.visitThis(visitor);
+        Assert.assertEquals("string('MyTestLibrary)", visitor.toString());
+    }
+}


### PR DESCRIPTION
Currently ExpressionParser throws StringIndexOutOfBoundsException while parsing string literal with included quote char.
